### PR TITLE
maintainers: add Dallos

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1694,6 +1694,16 @@
     githubId = 4331004;
     name = "Naoya Hatta";
   };
+  Dallos = {
+    name = "1010";
+    email = "1010@alsejk.ch";
+    github = "Dallos";
+    githubId = 11308100;
+    keys = [{
+      longkeyid = "ed25519/0x708709C99802E961";
+      fingerprint = "EB5E 6CD0 3C59 41CC 3724  97DE 7087 09C9 9802 E961";
+    }];
+  };
   DamienCassou = {
     email = "damien@cassou.me";
     github = "DamienCassou";


### PR DESCRIPTION
###### Motivation for this change

Adding self as maintainer. Needed separate commit for https://github.com/NixOS/nixpkgs/pull/90160#discussion_r439101304.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
